### PR TITLE
Fix multiple-select questions showing incorrect answers

### DIFF
--- a/tanda quiz.html
+++ b/tanda quiz.html
@@ -4422,10 +4422,22 @@
         }
 
         function shuffleOptionsWithCorrect(options, correctIndex) {
-            const correctAnswer = options[correctIndex];
             const shuffled = shuffleArray(options);
 
-            // Update the correct index to match new position
+            // Handle multiple-select questions (correctIndex is an array)
+            if (Array.isArray(correctIndex)) {
+                const newCorrectIndices = correctIndex.map(idx => {
+                    const correctAnswer = options[idx];
+                    return shuffled.indexOf(correctAnswer);
+                });
+                return {
+                    options: shuffled,
+                    correct: newCorrectIndices
+                };
+            }
+
+            // Handle multiple-choice/true-false questions (correctIndex is a number)
+            const correctAnswer = options[correctIndex];
             const newCorrectIndex = shuffled.indexOf(correctAnswer);
 
             return {


### PR DESCRIPTION
Fixed bug in shuffleOptionsWithCorrect() where multiple-select questions with array-based correct answers ([0,1,2,4]) were being treated as single indices, causing all answers to be marked incorrect.

Now properly handles:
- Multiple-select: Maps each correct index to new shuffled position
- Multiple-choice: Handles single correct index as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)